### PR TITLE
Implement async summarization with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ FeedPulse is a modern RSS feed aggregation and summarization tool designed speci
 * **Team Collaboration**: Share curated feeds and summaries easily within your team, ensuring everyone is up-to-date.
 * **Browser-Friendly Interface**: Enjoy a clean, intuitive user interface optimized for easy readability and quick browsing.
 * **Customizable Feeds**: Tailor your news feed experience by selecting and organizing specific RSS sources relevant to your team's interests.
+* **Built-in Caching**: Recently fetched feeds are cached for faster responses.
+* **Async Summaries**: Articles are summarized concurrently for improved performance.
 
 ## Use Cases
 
@@ -22,7 +24,9 @@ To get started with FeedPulse, simply clone this repository and follow the provi
 ```bash
 git clone https://github.com/yourusername/FeedPulse.git
 cd FeedPulse
-# Follow setup instructions
+# Install dependencies and start the API
+pip install -r requirements.txt
+uvicorn main:app --reload
 ```
 
 ## Contributing

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,20 @@
+import time
+from typing import Any, Optional
+
+class SimpleCache:
+    def __init__(self, ttl: int = 600):
+        self.ttl = ttl
+        self.store: dict[str, tuple[Any, float]] = {}
+
+    def get(self, key: str) -> Optional[Any]:
+        value = self.store.get(key)
+        if not value:
+            return None
+        data, expires = value
+        if time.time() > expires:
+            self.store.pop(key, None)
+            return None
+        return data
+
+    def set(self, key: str, value: Any):
+        self.store[key] = (value, time.time() + self.ttl)

--- a/main.py
+++ b/main.py
@@ -1,24 +1,60 @@
-from fastapi import FastAPI
+import asyncio
+import logging
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException, Query
+from typing import Optional
+
 from rss_parser import parse_rss
 from llm_client import LLMClient, LLMConfig
+from cache import SimpleCache
 
 app = FastAPI()
+logging.basicConfig(level=logging.INFO)
+
+feed_cache = SimpleCache(ttl=600)
 
 llm_config = LLMConfig.load()
 
-@app.get("/summarize")
-def summarize_rss(rss_url: str):
-    articles = parse_rss(rss_url)
-    summaries = []
 
-    with LLMClient(llm_config) as llm:
-        for article in articles:
-            prompt = f"Summarize briefly: {article['title']} - {article['summary']}"
-            summary = llm.generate(prompt)
-            summaries.append({
-                'title': article['title'],
-                'link': article['link'],
-                'summary': summary
-            })
+def validate_url(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="Invalid RSS URL")
+    return url
+
+
+async def summarize_article(article: dict, llm: LLMClient) -> dict:
+    prompt = (
+        f"Title: {article['title']}\n\n{article['summary']}\n\n"
+        "Provide a brief summary in 2-3 sentences."
+    )
+    summary = await asyncio.to_thread(llm.generate, prompt)
+    return {
+        "title": article["title"],
+        "link": article["link"],
+        "summary": summary,
+    }
+
+
+@app.get("/summarize")
+async def summarize_rss(
+    rss_url: str = Query(..., alias="rss_url"), model: Optional[str] = None
+):
+    validate_url(rss_url)
+
+    articles = feed_cache.get(rss_url)
+    if articles is None:
+        articles = await asyncio.to_thread(parse_rss, rss_url)
+        feed_cache.set(rss_url, articles)
+
+    config = LLMConfig.load()
+    if model:
+        config.model_name = model
+
+    summaries = []
+    with LLMClient(config) as llm:
+        tasks = [summarize_article(article, llm) for article in articles]
+        summaries = await asyncio.gather(*tasks)
 
     return {"summaries": summaries}


### PR DESCRIPTION
## Summary
- add `SimpleCache` helper for caching feed results
- validate RSS URLs in a new async `/summarize` endpoint
- summarize articles concurrently for faster responses
- update README with instructions and new feature highlights

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_6844af133a3c8330b87c9c62e8153796