### PR TITLE
Fix FastAPI startup when running main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/yourusername/FeedPulse.git
 cd FeedPulse
 # Install dependencies and start the API
 pip install -r requirements.txt
-uvicorn main:app --reload
+python main.py  # or use `uvicorn main:app --reload`
 ```
 
 ## Contributing

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from typing import Optional
 from rss_parser import parse_rss
 from llm_client import LLMClient, LLMConfig
 from cache import SimpleCache
+import uvicorn
 
 app = FastAPI()
 logging.basicConfig(level=logging.INFO)
@@ -58,3 +59,7 @@ async def summarize_rss(
         summaries = await asyncio.gather(*tasks)
 
     return {"summaries": summaries}
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add uvicorn import and `__main__` block so running `python main.py` starts the server
- document the new command in the README

## Testing
- `python -m py_compile main.py llm_client.py rss_parser.py cache.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b17e93388330a20e2a2102a738bb