### PR TITLE
Add hashed-unique article storage and listing UI

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,54 @@
+import sqlite3
+import hashlib
+from pathlib import Path
+from typing import List, Dict
+
+DB_PATH = Path(__file__).resolve().parent / "articles.db"
+
+_conn = None
+
+def get_conn():
+    global _conn
+    if _conn is None:
+        _conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+        _conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS articles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                link TEXT,
+                summary TEXT,
+                date TEXT,
+                hash TEXT UNIQUE
+            )
+            """
+        )
+        _conn.commit()
+    return _conn
+
+def compute_hash(title: str, date: str) -> str:
+    return hashlib.sha256(f"{title}{date}".encode("utf-8")).hexdigest()
+
+def store_article(title: str, link: str, summary: str, date: str) -> bool:
+    conn = get_conn()
+    h = compute_hash(title, date)
+    try:
+        conn.execute(
+            "INSERT INTO articles (title, link, summary, date, hash) VALUES (?, ?, ?, ?, ?)",
+            (title, link, summary, date, h),
+        )
+        conn.commit()
+        return True
+    except sqlite3.IntegrityError:
+        return False
+
+def list_articles() -> List[Dict[str, str]]:
+    conn = get_conn()
+    cur = conn.execute(
+        "SELECT title, link, summary, date FROM articles ORDER BY id DESC"
+    )
+    rows = cur.fetchall()
+    return [
+        {"title": row[0], "link": row[1], "summary": row[2], "date": row[3]}
+        for row in rows
+    ]

--- a/rss_parser.py
+++ b/rss_parser.py
@@ -1,5 +1,11 @@
 import feedparser
 
+def _get_date(entry) -> str:
+    for key in ("published", "updated", "created", "pubDate"):
+        if key in entry:
+            return str(entry.get(key))
+    return ""
+
 def parse_rss(url):
     feed = feedparser.parse(url)
     articles = []
@@ -7,6 +13,7 @@ def parse_rss(url):
         articles.append({
             'title': entry.title,
             'link': entry.link,
-            'summary': entry.summary if 'summary' in entry else ''
+            'summary': entry.summary if 'summary' in entry else '',
+            'date': _get_date(entry),
         })
     return articles

--- a/templates/articles.html
+++ b/templates/articles.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>FeedPulse Articles</title>
+</head>
+<body>
+    <h1>Summarized Articles</h1>
+    <ul>
+    {% for article in articles %}
+        <li>
+            <a href="{{ article.link }}">{{ article.title }}</a><br/>
+            <small>{{ article.date }}</small>
+            <p>{{ article.summary }}</p>
+        </li>
+    {% else %}
+        <li>No articles found.</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement SQLite helper storing articles uniquely by a hash of title and date
- extend RSS parser to capture publication date information
- save summarized articles on generation
- provide `/articles` endpoint displaying stored articles via Jinja2 template

## Testing
- `python -m py_compile main.py rss_parser.py db.py llm_client.py cache.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b91dab4c8330a3f613c9290806f7