### PR TITLE
Add configurable RSS feed manager

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,9 @@ api_url = http://192.168.1.132:11434/api/generate
 model_name = deepseek-r1
 timeout = 60
 max_retries = 3
+
+[RSS]
+# List of RSS feed URLs. You can specify them separated by commas or on separate lines.
+feeds = https://example.com/feed.xml, https://example.org/rss
+# Interval in seconds between fetches
+interval = 600

--- a/feed_manager.py
+++ b/feed_manager.py
@@ -1,0 +1,58 @@
+import logging
+import time
+from configparser import ConfigParser
+from pathlib import Path
+from typing import List, Tuple
+
+from rss_parser import parse_rss
+from db import store_article
+
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.ini"
+
+
+def load_feed_config(path: Path = CONFIG_PATH) -> Tuple[List[str], int]:
+    parser = ConfigParser(interpolation=None)
+    read = parser.read(path)
+    if not read:
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    feeds: List[str] = []
+    if parser.has_option("RSS", "feeds"):
+        raw = parser.get("RSS", "feeds")
+        for line in raw.splitlines():
+            for part in line.split(','):
+                url = part.strip()
+                if url:
+                    feeds.append(url)
+
+    interval = parser.getint("RSS", "interval", fallback=3600)
+    return feeds, interval
+
+
+def fetch_and_store(url: str) -> None:
+    try:
+        articles = parse_rss(url)
+        for art in articles:
+            stored = store_article(art["title"], art["link"], art["summary"], art["date"])
+            if stored:
+                logging.info("Stored article from %s: %s", url, art["title"])
+    except Exception as exc:
+        logging.error("Failed to process %s: %s", url, exc)
+
+
+def run(config_path: Path = CONFIG_PATH) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+    logging.info("Feed manager started")
+    while True:
+        feeds, interval = load_feed_config(config_path)
+        if not feeds:
+            logging.warning("No feeds configured")
+        for url in feeds:
+            fetch_and_store(url)
+        logging.info("Waiting %s seconds before next fetch", interval)
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add a simple script `feed_manager.py` that periodically pulls RSS feeds
- extend `config.ini` with a `[RSS]` section for configuring feeds and interval

## Testing
- `python -m py_compile feed_manager.py`
- `python feed_manager.py` *(fails: ModuleNotFoundError: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_6844bbcd5c3c8330b45f777f7ae50586