### PR TITLE
Optimize feed ingestion and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ summarized articles rendered as a simple web page.
 
 FeedPulse includes a helper script, `feed_manager.py`, for automatically
 fetching and storing articles from multiple RSS feeds. Ensure you have installed
-the dependencies listed in `requirements.txt` before running it.
+the dependencies listed in `requirements.txt` before running it. The default
+`config.ini` lists several security news feeds which are fetched concurrently.
 
 1. Edit `config.ini` and list your feeds under the `[RSS]` section. You can
    provide one feed URL per line or separate them with commas. Adjust the
@@ -87,7 +88,8 @@ python feed_manager.py
 ```
 
 The script runs continuously, polling the configured feeds and persisting new
-articles to `articles.db`.
+articles to `articles.db`. Each cycle retrieves the ten most recent articles from
+every feed and skips entries that already exist in the database.
 
 ## Contributing
 

--- a/config.ini
+++ b/config.ini
@@ -6,6 +6,10 @@ max_retries = 3
 
 [RSS]
 # List of RSS feed URLs. You can specify them separated by commas or on separate lines.
-feeds = https://example.com/feed.xml, https://example.org/rss
+feeds = https://news.ycombinator.com/rss,
+        https://www.infosecurity-magazine.com/rss/news/,
+        https://krebsonsecurity.com/feed/,
+        https://www.schneier.com/feed/atom/,
+        https://threatpost.com/feed/
 # Interval in seconds between fetches
 interval = 600

--- a/feed_manager.py
+++ b/feed_manager.py
@@ -1,10 +1,10 @@
+import asyncio
 import logging
-import time
 from configparser import ConfigParser
 from pathlib import Path
 from typing import List, Tuple
 
-from rss_parser import parse_rss
+from rss_parser import parse_rss, DEFAULT_LIMIT
 from db import store_article
 
 
@@ -30,28 +30,39 @@ def load_feed_config(path: Path = CONFIG_PATH) -> Tuple[List[str], int]:
     return feeds, interval
 
 
-def fetch_and_store(url: str) -> None:
+async def fetch_and_store(url: str) -> None:
     try:
-        articles = parse_rss(url)
+        articles = await asyncio.to_thread(parse_rss, url, DEFAULT_LIMIT)
+        if len(articles) < DEFAULT_LIMIT:
+            logging.warning("%s returned %d articles", url, len(articles))
+        else:
+            logging.info("Fetched %d articles from %s", len(articles), url)
         for art in articles:
             stored = store_article(art["title"], art["link"], art["summary"], art["date"])
             if stored:
                 logging.info("Stored article from %s: %s", url, art["title"])
+            else:
+                logging.debug("Duplicate article skipped from %s: %s", url, art["title"])
     except Exception as exc:
         logging.error("Failed to process %s: %s", url, exc)
 
 
-def run(config_path: Path = CONFIG_PATH) -> None:
+async def run_async(config_path: Path = CONFIG_PATH) -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
     logging.info("Feed manager started")
     while True:
         feeds, interval = load_feed_config(config_path)
         if not feeds:
             logging.warning("No feeds configured")
-        for url in feeds:
-            fetch_and_store(url)
+        tasks = [fetch_and_store(url) for url in feeds]
+        if tasks:
+            await asyncio.gather(*tasks)
         logging.info("Waiting %s seconds before next fetch", interval)
-        time.sleep(interval)
+        await asyncio.sleep(interval)
+
+
+def run(config_path: Path = CONFIG_PATH) -> None:
+    asyncio.run(run_async(config_path))
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 
-from rss_parser import parse_rss
+from rss_parser import parse_rss, DEFAULT_LIMIT
 from llm_client import LLMClient, LLMConfig
 from cache import SimpleCache
 from db import store_article, list_articles
@@ -55,7 +55,7 @@ async def summarize_rss(
 
     articles = feed_cache.get(rss_url)
     if articles is None:
-        articles = await asyncio.to_thread(parse_rss, rss_url)
+        articles = await asyncio.to_thread(parse_rss, rss_url, DEFAULT_LIMIT)
         feed_cache.set(rss_url, articles)
 
     config = LLMConfig.load()

--- a/rss_parser.py
+++ b/rss_parser.py
@@ -1,4 +1,8 @@
 import feedparser
+from typing import List, Dict
+
+
+DEFAULT_LIMIT = 10
 
 def _get_date(entry) -> str:
     for key in ("published", "updated", "created", "pubDate"):
@@ -6,14 +10,14 @@ def _get_date(entry) -> str:
             return str(entry.get(key))
     return ""
 
-def parse_rss(url):
+def parse_rss(url: str, limit: int = DEFAULT_LIMIT) -> List[Dict[str, str]]:
     feed = feedparser.parse(url)
-    articles = []
-    for entry in feed.entries[:5]:  # Limiting to latest 5 entries
+    articles: List[Dict[str, str]] = []
+    for entry in feed.entries[:limit]:
         articles.append({
-            'title': entry.title,
-            'link': entry.link,
-            'summary': entry.summary if 'summary' in entry else '',
-            'date': _get_date(entry),
+            "title": entry.title,
+            "link": entry.link,
+            "summary": entry.summary if "summary" in entry else "",
+            "date": _get_date(entry),
         })
     return articles


### PR DESCRIPTION
## Summary
- update `config.ini` with default security news feeds
- allow specifying article limit in `rss_parser`
- fetch feeds concurrently with `feed_manager` and log results
- use the new limit in the API and manager
- document concurrent ingestion and article limit in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844c355b5708330bf1fefe813e9314e