### PR TITLE
Implement article rewriting with duplication tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # FeedPulse
 
-FeedPulse is a modern RSS feed aggregation and summarization tool designed specifically for teams. It transforms RSS feeds into concise, blog-style summaries directly accessible via your browser, helping teams stay informed, organized, and aligned on the latest news and updates relevant to their workflow.
+FeedPulse is a modern RSS feed aggregation and rewriting tool designed specifically for teams. It transforms RSS feeds into concise, blog-style articles rewritten by an LLM and directly accessible via your browser, helping teams stay informed, organized, and aligned on the latest news and updates relevant to their workflow.
 
 ## Features
 
-* **Automated Summaries**: FeedPulse automatically extracts key insights and summarizes RSS content into clear, concise blog-style articles.
+* **Automated Rewrites**: FeedPulse automatically rewrites RSS content into clear, concise blog-style articles.
 * **Team Collaboration**: Share curated feeds and summaries easily within your team, ensuring everyone is up-to-date.
 * **Browser-Friendly Interface**: Enjoy a clean, intuitive user interface optimized for easy readability and quick browsing.
 * **Customizable Feeds**: Tailor your news feed experience by selecting and organizing specific RSS sources relevant to your team's interests.
 * **Built-in Caching**: Recently fetched feeds are cached for faster responses.
-* **Async Summaries**: Articles are summarized concurrently for improved performance.
+* **Async Rewrites**: Articles are rewritten concurrently for improved performance.
 
 ## Use Cases
 
@@ -49,7 +49,7 @@ The server will listen on `http://localhost:8000` by default.
 
 ## Usage Guide
 
-### Summarize a Feed
+### Rewrite a Feed
 
 Send a GET request to `/summarize` with the RSS feed URL:
 
@@ -63,13 +63,13 @@ Optionally, specify a different model using the `model` query parameter:
 curl "http://localhost:8000/summarize?rss_url=https://example.com/feed.xml&model=my-model"
 ```
 
-The response contains a JSON array of article titles, links, dates and generated
-summaries. Each request also stores the results in a local SQLite database.
+The response contains a JSON array of article titles, links, dates and rewritten
+content. Each request also stores the results in a local SQLite database.
 
 ### View Stored Articles
 
 Open `http://localhost:8000/articles` in your browser to see previously
-summarized articles rendered as a simple web page.
+rewritten articles rendered as a simple web page.
 
 ## Feed Manager
 

--- a/db.py
+++ b/db.py
@@ -1,7 +1,7 @@
 import sqlite3
 import hashlib
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 DB_PATH = Path(__file__).resolve().parent / "articles.db"
 
@@ -13,11 +13,22 @@ def get_conn():
         _conn = sqlite3.connect(DB_PATH, check_same_thread=False)
         _conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS articles (
+            CREATE TABLE IF NOT EXISTS processed_articles (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 title TEXT,
                 link TEXT,
-                summary TEXT,
+                date TEXT,
+                hash TEXT UNIQUE
+            )
+            """
+        )
+        _conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rewritten_articles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                link TEXT,
+                content TEXT,
                 date TEXT,
                 hash TEXT UNIQUE
             )
@@ -29,26 +40,52 @@ def get_conn():
 def compute_hash(title: str, date: str) -> str:
     return hashlib.sha256(f"{title}{date}".encode("utf-8")).hexdigest()
 
-def store_article(title: str, link: str, summary: str, date: str) -> bool:
+def store_processed_article(title: str, link: str, date: str) -> bool:
     conn = get_conn()
     h = compute_hash(title, date)
     try:
         conn.execute(
-            "INSERT INTO articles (title, link, summary, date, hash) VALUES (?, ?, ?, ?, ?)",
-            (title, link, summary, date, h),
+            "INSERT INTO processed_articles (title, link, date, hash) VALUES (?, ?, ?, ?)",
+            (title, link, date, h),
         )
         conn.commit()
         return True
     except sqlite3.IntegrityError:
         return False
 
-def list_articles() -> List[Dict[str, str]]:
+
+def store_rewritten_article(title: str, link: str, content: str, date: str) -> bool:
+    conn = get_conn()
+    h = compute_hash(title, date)
+    try:
+        conn.execute(
+            "INSERT INTO rewritten_articles (title, link, content, date, hash) VALUES (?, ?, ?, ?, ?)",
+            (title, link, content, date, h),
+        )
+        conn.commit()
+        return True
+    except sqlite3.IntegrityError:
+        return False
+
+def get_rewritten_article(article_hash: str) -> Optional[Dict[str, str]]:
     conn = get_conn()
     cur = conn.execute(
-        "SELECT title, link, summary, date FROM articles ORDER BY id DESC"
+        "SELECT title, link, content, date FROM rewritten_articles WHERE hash = ?",
+        (article_hash,),
+    )
+    row = cur.fetchone()
+    if row:
+        return {"title": row[0], "link": row[1], "content": row[2], "date": row[3]}
+    return None
+
+
+def list_rewritten_articles() -> List[Dict[str, str]]:
+    conn = get_conn()
+    cur = conn.execute(
+        "SELECT title, link, content, date FROM rewritten_articles ORDER BY id DESC"
     )
     rows = cur.fetchall()
     return [
-        {"title": row[0], "link": row[1], "summary": row[2], "date": row[3]}
+        {"title": row[0], "link": row[1], "content": row[2], "date": row[3]}
         for row in rows
     ]

--- a/templates/articles.html
+++ b/templates/articles.html
@@ -5,13 +5,13 @@
     <title>FeedPulse Articles</title>
 </head>
 <body>
-    <h1>Summarized Articles</h1>
+    <h1>Rewritten Articles</h1>
     <ul>
     {% for article in articles %}
         <li>
             <a href="{{ article.link }}">{{ article.title }}</a><br/>
             <small>{{ article.date }}</small>
-            <p>{{ article.summary }}</p>
+            <p>{{ article.content }}</p>
         </li>
     {% else %}
         <li>No articles found.</li>


### PR DESCRIPTION
## Summary
- track processed articles in `processed_articles`
- store final rewrites in `rewritten_articles`
- update FastAPI app to generate rewrites and serve them from the DB
- enhance feed manager with rewriting logic
- update templates and documentation for new workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python -c "import feed_manager, main, db; print('modules import ok')"` *(fails: ModuleNotFoundError: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_6844c6a81a0c8330830de6b33c7bbe58