### PR TITLE
Add systemd units for scheduled fetching and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,33 @@ The script runs continuously, polling the configured feeds and persisting new
 articles to `articles.db`. Each cycle retrieves the ten most recent articles from
 every feed and skips entries that already exist in the database.
 
+### Daily Fetch with systemd
+
+If you prefer to fetch feeds once per day rather than running the manager
+continuously, use the systemd units in the `systemd` folder. Copy the files to
+`/etc/systemd/system/` and adjust the paths inside them to match the location of
+your FeedPulse checkout. Then enable the timer:
+
+```bash
+sudo systemctl enable feed-manager.timer
+sudo systemctl start feed-manager.timer
+```
+
+The timer runs `feed_manager.py` every morning at 06:00 and stores any new
+articles in `articles.db`.
+
+### Running the API as a Service
+
+To keep the FastAPI server available in the background, install the provided
+`feedpulse.service` unit in the same way:
+
+```bash
+sudo systemctl enable feedpulse.service
+sudo systemctl start feedpulse.service
+```
+
+The service launches `main.py` and will automatically restart on failure.
+
 ## Contributing
 
 We welcome contributions from the community! Feel free to submit issues, suggestions, or pull requests.

--- a/systemd/feed-manager.service
+++ b/systemd/feed-manager.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=FeedPulse Daily Fetcher
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/feedpulse
+ExecStart=/usr/bin/python3 /opt/feedpulse/feed_manager.py
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/feed-manager.timer
+++ b/systemd/feed-manager.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run FeedPulse fetcher each morning
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/feedpulse.service
+++ b/systemd/feedpulse.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FeedPulse API Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/feedpulse
+ExecStart=/usr/bin/python3 /opt/feedpulse/main.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add service units for running the API and a daily fetcher
- document how to use the systemd units

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844cf47a2b483309c87d0b42ea030ed