### PR TITLE
Modify feed manager to run once by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ the dependencies listed in `requirements.txt` before running it. The default
 python feed_manager.py
 ```
 
-The script runs continuously, polling the configured feeds and persisting new
-articles to `articles.db`. Each cycle retrieves the ten most recent articles from
-every feed and skips entries that already exist in the database.
+By default the script fetches the configured feeds once and stores any new
+articles in `articles.db`. Use the `--loop` flag to poll continuously at the
+interval specified in `config.ini`.
 
 ### Daily Fetch with systemd
 


### PR DESCRIPTION
## Summary
- allow `feed_manager.py` to run once by default
- support `--loop` option to keep running at the configured interval
- document new behaviour in README

## Testing
- `python -m py_compile feed_manager.py`
- `python feed_manager.py --help` *(fails: ModuleNotFoundError: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_6844d67f61188330a3aeba11a539d2f5