### PR TITLE
Add article management dashboard

### DIFF
--- a/feed_manager.py
+++ b/feed_manager.py
@@ -47,7 +47,13 @@ async def rewrite_and_store(
 
         prompt = prompt_template.format(title=article["title"], summary=article["summary"])
         rewritten = await asyncio.to_thread(llm.generate, prompt)
-        store_rewritten_article(article["title"], article["link"], rewritten, article.get("date", ""))
+        store_rewritten_article(
+            article["title"],
+            article["link"],
+            rewritten,
+            article.get("date", ""),
+            None,
+        )
         logging.info("Stored rewritten article from %s: %s", source, article["title"])
     except Exception as exc:
         logging.error("Failed to rewrite %s from %s: %s", article.get("title"), source, exc)

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,81 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+interface Article {
+  id: number;
+  title: string;
+  link: string;
+  date: string;
+  content: string;
+  category: string | null;
+}
+
+async function fetchArticles(): Promise<Article[]> {
+  const res = await fetch('/api/articles');
+  const data = await res.json();
+  return data.articles;
+}
+
 export default function Dashboard() {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery(['articles'], fetchArticles);
+
+  const deleteMutation = useMutation(
+    async (id: number) => {
+      await fetch(`/api/articles/${id}`, { method: 'DELETE' });
+    },
+    { onSuccess: () => queryClient.invalidateQueries(['articles']) }
+  );
+
+  const categoryMutation = useMutation(
+    async ({ id, category }: { id: number; category: string }) => {
+      await fetch(`/api/articles/${id}/category`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category }),
+      });
+    },
+    { onSuccess: () => queryClient.invalidateQueries(['articles']) }
+  );
+
+  if (isLoading) return <p>Loading...</p>;
+
+  function ArticleRow({ article }: { article: Article }) {
+    const [cat, setCat] = useState(article.category || '');
+    return (
+      <div className="border p-4 rounded shadow flex justify-between items-start">
+        <div>
+          <h3 className="font-semibold">
+            <a href={article.link} target="_blank" rel="noreferrer">
+              {article.title}
+            </a>
+          </h3>
+          <p className="text-sm text-gray-500 mb-2">{article.date}</p>
+          <input
+            className="border rounded px-2 py-1 text-sm"
+            value={cat}
+            onChange={(e) => setCat(e.target.value)}
+            onBlur={() =>
+              categoryMutation.mutate({ id: article.id, category: cat })
+            }
+            placeholder="Category"
+          />
+        </div>
+        <button
+          className="text-red-600 hover:underline"
+          onClick={() => deleteMutation.mutate(article.id)}
+        >
+          Delete
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">Latest Feeds</h2>
-      <p className="text-gray-600">This is a placeholder dashboard.</p>
+    <div className="space-y-4">
+      {data?.map((a) => (
+        <ArticleRow key={a.id} article={a} />
+      ))}
     </div>
   );
 }

--- a/main.py
+++ b/main.py
@@ -15,6 +15,8 @@ from db import (
     store_rewritten_article,
     get_rewritten_article,
     list_rewritten_articles,
+    delete_article,
+    update_article_category,
     compute_hash,
 )
 from fastapi.responses import RedirectResponse
@@ -49,8 +51,15 @@ async def rewrite_article(article: dict, llm: LLMClient, prompt_template: str) -
         "link": article["link"],
         "content": rewritten,
         "date": article.get("date", ""),
+        "category": None,
     }
-    store_rewritten_article(result["title"], result["link"], result["content"], result["date"])
+    store_rewritten_article(
+        result["title"],
+        result["link"],
+        result["content"],
+        result["date"],
+        result["category"],
+    )
     return result
 
 
@@ -99,6 +108,23 @@ async def show_articles(request: Request):
 @app.get("/api/articles")
 async def api_articles():
     return {"articles": list_rewritten_articles()}
+
+
+@app.delete("/api/articles/{article_id}")
+async def api_delete_article(article_id: int):
+    if delete_article(article_id):
+        return {"status": "deleted"}
+    raise HTTPException(status_code=404, detail="Article not found")
+
+
+@app.post("/api/articles/{article_id}/category")
+async def api_set_category(article_id: int, data: dict):
+    category = data.get("category")
+    if category is None:
+        raise HTTPException(status_code=400, detail="Missing category")
+    if update_article_category(article_id, category):
+        return {"status": "updated"}
+    raise HTTPException(status_code=404, detail="Article not found")
 
 
 


### PR DESCRIPTION
## Summary
- extend `rewritten_articles` with `category` field and new helpers
- add endpoints to remove articles and set categories
- store blank category when rewriting
- support new schema in feed manager
- implement responsive dashboard list view for managing articles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458c20b0e883309187cb6345708ecd