### PR TITLE
Fix React frontend connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The service launches `main.py` and will automatically restart on failure.
 
 ## Front-End Interface
 
-A React + Vite front-end is available in the `frontend/` folder. After installing Node.js, run:
+A React + Vite front-end is available in the `frontend/` folder. Start the FastAPI backend first and then run the front-end:
 
 ```bash
 cd frontend
@@ -135,7 +135,9 @@ npm install
 npm run dev
 ```
 
-This starts a development server on port 5173 that communicates with the FastAPI backend. Build a production bundle with `npm run build`.
+This starts a development server on port 5173. Requests to `/api` are automatically proxied to the backend running on port 8000, so make sure the API server is running. Build a production bundle with `npm run build`.
+
+Open `http://localhost:5173/explore` in your browser to browse the rewritten articles stored in the database.
 
 
 ## Contributing

--- a/frontend/src/pages/FeedExplorer.tsx
+++ b/frontend/src/pages/FeedExplorer.tsx
@@ -9,14 +9,18 @@ interface Article {
 
 async function fetchArticles(): Promise<Article[]> {
   const res = await fetch('/api/articles');
+  if (!res.ok) {
+    throw new Error('API request failed');
+  }
   const data = await res.json();
   return data.articles;
 }
 
 export default function FeedExplorer() {
-  const { data, isLoading } = useQuery(['articles'], fetchArticles);
+  const { data, isLoading, error } = useQuery(['articles'], fetchArticles);
 
   if (isLoading) return <p>Loading...</p>;
+  if (error) return <p className="text-red-600">Failed to load articles. Verify the backend connection.</p>;
 
   return (
     <div className="space-y-4">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
   },
 });

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 
@@ -22,6 +23,13 @@ import uvicorn
 
 app = FastAPI()
 logging.basicConfig(level=logging.INFO)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 templates = Jinja2Templates(directory="templates")
 


### PR DESCRIPTION
## Summary
- fix React query error handling and show connection issue
- proxy Vite dev server `/api` requests to the backend
- enable CORS support in FastAPI
- document frontend steps and the explore page in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594b258588330bfa57a9b600bcbd6