### PR TITLE
Fix empty explore page

### DIFF
--- a/frontend/src/pages/FeedExplorer.tsx
+++ b/frontend/src/pages/FeedExplorer.tsx
@@ -21,6 +21,13 @@ export default function FeedExplorer() {
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p className="text-red-600">Failed to load articles. Verify the backend connection.</p>;
+  if (!data || data.length === 0) {
+    return (
+      <p className="text-gray-600">
+        No articles found. Run the feed manager or hit the /summarize endpoint to add some.
+      </p>
+    );
+  }
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- show a helpful message on the Explore page when there are no articles stored

## Testing
- `python -m py_compile *.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684597a9cdc4833092a417c164093b01