### PR TITLE
Add article limit parameter and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ The server will listen on `http://localhost:8000` by default.
 
 ### Rewrite a Feed
 
-Send a GET request to `/summarize` with the RSS feed URL:
+Send a GET request to `/summarize` with the RSS feed URL. By default the
+endpoint rewrites the latest five entries, but you can control this with the
+`limit` query parameter:
 
 ```bash
 curl "http://localhost:8000/summarize?rss_url=https://example.com/feed.xml"
+curl "http://localhost:8000/summarize?rss_url=https://example.com/feed.xml&limit=3"
 ```
 
 Optionally, specify a different model using the `model` query parameter or

--- a/main.py
+++ b/main.py
@@ -67,13 +67,15 @@ async def summarize_rss(
     rss_url: str = Query(..., alias="rss_url"),
     model: Optional[str] = None,
     prompt: Optional[str] = None,
+    limit: int = DEFAULT_LIMIT,
 ):
     validate_url(rss_url)
 
-    articles = feed_cache.get(rss_url)
+    cache_key = f"{rss_url}:{limit}"
+    articles = feed_cache.get(cache_key)
     if articles is None:
-        articles = await asyncio.to_thread(parse_rss, rss_url, DEFAULT_LIMIT)
-        feed_cache.set(rss_url, articles)
+        articles = await asyncio.to_thread(parse_rss, rss_url, limit)
+        feed_cache.set(cache_key, articles)
 
     config = LLMConfig.load()
     if model:

--- a/rss_parser.py
+++ b/rss_parser.py
@@ -3,7 +3,8 @@ import requests
 from typing import List, Dict, Tuple, Optional
 
 
-DEFAULT_LIMIT = 1
+# Number of articles returned when no explicit limit is provided
+DEFAULT_LIMIT = 5
 
 def _get_date(entry) -> str:
     for key in ("published", "updated", "created", "pubDate"):


### PR DESCRIPTION
## Summary
- allow callers to choose how many posts to rewrite via a new `limit` query parameter
- cache articles per limit value
- bump the default limit to 5 articles
- document the new behaviour in the README

## Testing
- `python -m py_compile *.py`
- `pytest -q` *(fails: no tests)*
- `pip install -r requirements.txt` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684599f6a004833086769f80215c6cf9