### PR TITLE
Add article deletion page

### DIFF
--- a/db.py
+++ b/db.py
@@ -101,6 +101,36 @@ def list_rewritten_articles() -> List[Dict[str, str]]:
     ]
 
 
+def list_rewritten_articles_with_id() -> List[Dict[str, str]]:
+    conn = get_conn()
+    cur = conn.execute(
+        "SELECT id, title, link, content, date FROM rewritten_articles ORDER BY id DESC"
+    )
+    rows = cur.fetchall()
+    return [
+        {
+            "id": row[0],
+            "title": row[1],
+            "link": row[2],
+            "content": row[3],
+            "date": row[4],
+        }
+        for row in rows
+    ]
+
+
+def delete_rewritten_articles(ids: List[int]) -> None:
+    if not ids:
+        return
+    conn = get_conn()
+    placeholders = ",".join("?" for _ in ids)
+    conn.execute(
+        f"DELETE FROM rewritten_articles WHERE id IN ({placeholders})",
+        ids,
+    )
+    conn.commit()
+
+
 def record_feed_status(url: str, success: bool, reason: str) -> None:
     conn = get_conn()
     conn.execute(

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from urllib.parse import urlparse
 
-from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi import FastAPI, HTTPException, Query, Request, Form
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.templating import Jinja2Templates
@@ -16,6 +16,8 @@ from db import (
     store_rewritten_article,
     get_rewritten_article,
     list_rewritten_articles,
+    list_rewritten_articles_with_id,
+    delete_rewritten_articles,
     compute_hash,
 )
 from fastapi.responses import RedirectResponse
@@ -109,6 +111,20 @@ async def show_articles(request: Request):
 @app.get("/api/articles")
 async def api_articles():
     return {"articles": list_rewritten_articles()}
+
+
+@app.get("/edit", response_class=HTMLResponse)
+async def edit_articles(request: Request):
+    articles = list_rewritten_articles_with_id()
+    return templates.TemplateResponse(
+        "edit.html", {"request": request, "articles": articles}
+    )
+
+
+@app.post("/edit")
+async def delete_articles(ids: list[int] = Form(...)):
+    delete_rewritten_articles(ids)
+    return RedirectResponse(url="/edit", status_code=303)
 
 
 

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit Articles</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f5f8fa; margin:0; display:flex; justify-content:center; }
+        .container { width: 600px; max-width: 100%; margin-top: 20px; }
+        .tweet { background:#fff; border:1px solid #e1e8ed; border-radius:16px; padding:16px; margin-bottom:12px; display:flex; align-items:flex-start; }
+        .tweet-info { flex:1; }
+        .tweet h2 { font-size:20px; margin:0 0 4px 0; }
+        .tweet h2 a { text-decoration:none; color:#1da1f2; }
+        .tweet .date { color:#657786; font-size:14px; margin-bottom:8px; }
+        .tweet p { margin:0; line-height:1.5; white-space:pre-wrap; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <form method="post" action="/edit">
+            {% if articles %}
+                {% for article in articles %}
+                    <div class="tweet">
+                        <input type="checkbox" name="ids" value="{{ article.id }}" style="margin-right:10px;" />
+                        <div class="tweet-info">
+                            <h2><a href="{{ article.link }}">{{ article.title }}</a></h2>
+                            <div class="date">{{ article.date }}</div>
+                            <p>{{ article.content }}</p>
+                        </div>
+                    </div>
+                {% endfor %}
+                <button type="submit">Delete Selected</button>
+            {% else %}
+                <p>No articles found.</p>
+            {% endif %}
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add database helpers to list articles with id and delete by id
- add `/edit` GET and POST endpoints
- create `edit.html` template with checkboxes for deletion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845ca8d511483308af4b4da7d09ca02