### PR TITLE
Render markdown on article page

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ content. Each request also stores the results in a local SQLite database.
 
 ### View Stored Articles
 
-Open `http://localhost:8000/articles` in your browser to view your rewritten articles styled in a tweet-like layout.
+Open `http://localhost:8000/articles` in your browser to view your rewritten articles styled in a tweet-like layout. The page now converts any Markdown in the article summaries to HTML on the client using [marked.js](https://github.com/markedjs/marked) for improved readability.
 
 ## Feed Manager
 

--- a/templates/articles.html
+++ b/templates/articles.html
@@ -12,7 +12,7 @@
         article h2 { margin-top:0; }
         article h2 a { text-decoration:none; color:#0d6efd; }
         article time { color:#555; font-size:0.9em; display:block; margin-bottom:10px; }
-        article .content { white-space:pre-wrap; line-height:1.5; }
+        article .content { line-height:1.5; }
     </style>
 </head>
 <body>
@@ -30,5 +30,14 @@
             <p>No articles found.</p>
         {% endif %}
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            document.querySelectorAll('.content').forEach(function(el) {
+                const md = el.textContent;
+                el.innerHTML = marked.parse(md);
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert stored article markdown to HTML on the articles page using marked.js
- document markdown rendering in README

## Testing
- `python -m py_compile main.py cache.py db.py feed_manager.py llm_client.py rss_parser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d80176f4833098467ee592842ed1