### PR TITLE
feat: scaffold monorepo layout with compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ cd FeedPulse
 pip install -r requirements.txt
 ```
 
+### Docker Compose
+
+The repository now follows a simple monorepo layout with separate `api`,
+`worker`, and `frontend` services. You can spin up the entire stack using Docker
+Compose:
+
+```bash
+docker compose up --build
+```
+
+This starts PostgreSQL, Redis, the FastAPI API, a Celery worker and a minimal
+frontend container.
+
 ### Configuration
 
 The application relies on a running language model service. Edit `config.ini` to

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY .. .
+CMD ["python", "api/app.py"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,1 @@
+# API service

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,147 @@
+import asyncio
+import logging
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException, Query, Request, Form
+from fastapi.responses import HTMLResponse
+from fastapi.responses import Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.templating import Jinja2Templates
+from typing import Optional
+
+from rss_parser import parse_rss, DEFAULT_LIMIT
+from llm_client import LLMClient, LLMConfig
+from cache import SimpleCache
+from db import (
+    store_processed_article,
+    store_rewritten_article,
+    get_rewritten_article,
+    list_rewritten_articles,
+    list_rewritten_articles_with_id,
+    delete_rewritten_articles,
+    compute_hash,
+)
+from fastapi.responses import RedirectResponse
+import uvicorn
+
+app = FastAPI()
+logging.basicConfig(level=logging.INFO)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+templates = Jinja2Templates(directory="templates")
+
+feed_cache = SimpleCache(ttl=600)
+
+
+def validate_url(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="Invalid RSS URL")
+    return url
+
+
+async def rewrite_article(article: dict, llm: LLMClient, prompt_template: str) -> dict:
+    h = compute_hash(article["title"], article.get("date", ""))
+    if not store_processed_article(article["title"], article["link"], article.get("date", "")):
+        existing = get_rewritten_article(h)
+        if existing:
+            return existing
+
+    prompt = prompt_template.format(title=article["title"], summary=article["summary"])
+    rewritten = await asyncio.to_thread(llm.generate, prompt)
+    result = {
+        "title": article["title"],
+        "link": article["link"],
+        "content": rewritten,
+        "date": article.get("date", ""),
+    }
+    store_rewritten_article(result["title"], result["link"], result["content"], result["date"])
+    return result
+
+
+@app.get("/summarize")
+async def summarize_rss(
+    rss_url: str = Query(..., alias="rss_url"),
+    model: Optional[str] = None,
+    prompt: Optional[str] = None,
+    limit: int = DEFAULT_LIMIT,
+):
+    validate_url(rss_url)
+
+    cache_key = f"{rss_url}:{limit}"
+    articles = feed_cache.get(cache_key)
+    if articles is None:
+        articles = await asyncio.to_thread(parse_rss, rss_url, limit)
+        feed_cache.set(cache_key, articles)
+
+    config = LLMConfig.load()
+    if model:
+        config.model_name = model
+    if prompt:
+        config.rewrite_prompt = prompt
+
+    results = []
+    with LLMClient(config) as llm:
+        tasks = [
+            rewrite_article(article, llm, config.rewrite_prompt)
+            for article in articles
+        ]
+        results = await asyncio.gather(*tasks)
+
+    return {"articles": results}
+
+
+@app.get("/", include_in_schema=False)
+async def index():
+    return RedirectResponse(url="/articles")
+
+
+@app.get("/articles", response_class=HTMLResponse)
+async def show_articles(request: Request):
+    return templates.TemplateResponse(
+        "articles.html", {"request": request}
+    )
+
+
+@app.get("/article_list", response_class=HTMLResponse)
+async def article_list(request: Request):
+    articles = list_rewritten_articles()
+    return templates.TemplateResponse(
+        "article_list.html", {"request": request, "articles": articles}
+    )
+
+@app.get("/api/articles")
+async def api_articles():
+    return {"articles": list_rewritten_articles()}
+
+
+@app.get("/edit", response_class=HTMLResponse)
+async def edit_articles(request: Request):
+    articles = list_rewritten_articles_with_id()
+    return templates.TemplateResponse(
+        "edit.html", {"request": request, "articles": articles}
+    )
+
+
+@app.post("/edit")
+async def delete_articles(ids: list[int] = Form(...)):
+    delete_rewritten_articles(ids)
+    return RedirectResponse(url="/edit", status_code=303)
+
+
+@app.post("/delete/{article_id}")
+async def delete_article(article_id: int):
+    delete_rewritten_articles([article_id])
+    return Response(status_code=204)
+
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: feedpulse
+      POSTGRES_PASSWORD: feedpulse
+      POSTGRES_DB: feedpulse
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+  api:
+    build: ./api
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+  worker:
+    build: ./worker
+    volumes:
+      - .:/app
+    depends_on:
+      - api
+      - redis
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - api
+volumes:
+  pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,1 @@
+# Frontend application

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "feedpulse-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "echo building frontend"
+  }
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY .. .
+CMD ["celery", "-A", "worker.tasks", "worker", "--loglevel=info"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,1 @@
+# Worker service

--- a/worker/worker/__init__.py
+++ b/worker/worker/__init__.py
@@ -1,0 +1,4 @@
+from celery import Celery
+app = Celery('feedpulse', broker='redis://redis:6379/0')
+
+from . import tasks

--- a/worker/worker/tasks.py
+++ b/worker/worker/tasks.py
@@ -1,0 +1,14 @@
+from . import app
+from llm_client import LLMClient, LLMConfig
+from rss_parser import parse_rss
+from db import store_rewritten_article, store_processed_article, compute_hash
+
+@app.task
+def rewrite_feed_article(article: dict):
+    config = LLMConfig.load()
+    with LLMClient(config) as llm:
+        prompt = config.rewrite_prompt.format(title=article['title'], summary=article['summary'])
+        result = llm.generate(prompt)
+    store_processed_article(article['title'], article['link'], article.get('date', ''))
+    store_rewritten_article(article['title'], article['link'], result, article.get('date', ''))
+


### PR DESCRIPTION
## Summary
- restructure repo with api, worker and frontend directories
- add Dockerfiles for each service
- wire up docker-compose stack
- document how to run docker compose

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845f61ade2c8330a377cff17607e12e